### PR TITLE
win_security_policy: allow removing values (resolves #40869)

### DIFF
--- a/lib/ansible/modules/windows/win_security_policy.ps1
+++ b/lib/ansible/modules/windows/win_security_policy.ps1
@@ -194,6 +194,10 @@ if ($will_change -eq $true) {
             if ($new_value -cne $value) {
                 Fail-Json $result "Failed to change the value for key '$key' in section '$section', the value is still $new_value"
             }
+        } elseif ($value -eq "") {
+            # Value was empty, so OK if no longer in the result
+            # Just print a warning
+            Add-Warning -obj $result -message "The key '$key' in section '$section' was reset to empty value."
         } else {
             Fail-Json $result "The key '$key' in section '$section' is not a valid key, cannot set this value"
         }


### PR DESCRIPTION
##### SUMMARY
This fix allows resetting a value (setting it to empty) using `win_security_policy`. 
Note that it throws a warning when doing this, as it might not be the typically expected behavior; but it is very useful in certain use cases,

Fixes #40869

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_security_policy

##### ANSIBLE VERSION

```
ansible 2.5.2
  config file = /home_local/ansible/automation/ansible.cfg
  configured module search path = [u'/home_local/ansible/automation/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```
